### PR TITLE
eswin: harmonize device-tree

### DIFF
--- a/arch/riscv/boot/dts/eswin/Makefile
+++ b/arch/riscv/boot/dts/eswin/Makefile
@@ -2,7 +2,7 @@
 dtb-$(CONFIG_SOC_SIFIVE) += eswin-win2030.dtb \
 							eic7700-evb.dtb \
 							eic7700-evb-a2.dtb \
-							hifive-premier-p550.dtb \
+							eic7700-hifive-premier-p550.dtb \
 							eic7702-evb-a1-d0.dtb \
 							eic7702-evb-a1-d1.dtb
 

--- a/arch/riscv/boot/dts/eswin/eic7700-hifive-premier-p550.dts
+++ b/arch/riscv/boot/dts/eswin/eic7700-hifive-premier-p550.dts
@@ -38,9 +38,8 @@
 / {
 	#address-cells = <2>;
 	#size-cells = <2>;
-	model = "ESWIN EIC7700";
-	compatible = "sifive,hifive-unmatched-a00", "sifive,fu740-c000",
-		     "sifive,fu740", "eswin,eic7700";
+	model = "SiFive HiFive Premier P550";
+	compatible = "sifive,hifive-premier-p550", "eswin,eic7700";
 
 	aliases {
 		serial0 = &d0_uart0;


### PR DESCRIPTION
We should use a device-tree name that is upstreamable.

* use eswin/eic7700-hifive-premier-p550.dtb as device-tree name
* use "SiFive HiFive Premier P550" as model property
* use  "sifive,hifive-premier-p550", "eswin,eic7700" as compatible strings