### PR TITLE
fix(drivers/spi): re-add dropped SPI ACPI symbol

### DIFF
--- a/drivers/spi/spi-eswin.c
+++ b/drivers/spi/spi-eswin.c
@@ -1131,6 +1131,13 @@ static const struct of_device_id eswin_spi_mmio_of_match[] = {
 MODULE_DEVICE_TABLE(of, eswin_spi_mmio_of_match);
 
 
+static const struct acpi_device_id eswin_spi_mmio_acpi_match[] = {
+	{"eswin,bootspi", 0},
+	{}
+};
+MODULE_DEVICE_TABLE(acpi, eswin_spi_mmio_acpi_match);
+
+
 static struct platform_driver eswin_spi_mmio_driver = {
 	.probe		= eswin_spi_mmio_probe,
 	.remove_new	= eswin_spi_mmio_remove,


### PR DESCRIPTION
Commit d3575329b78fe1507dcef677de0e32cc314829d6 moved a lot of this code from spi-eswin-bootspi.c to spi-eswin.c and renamed eswin_bootspi_acpi_match to eswin_spi_mmio_acpi_match.

In so doing, it removed the definition of eswin_spi_mmio_acpi_match, which causes build failures. This re-adds that definition.

Fixes #12 