### PR TITLE
Linux 6.6.18 eic7x out-of-tree build fixes

### DIFF
--- a/drivers/media/i2c/Makefile
+++ b/drivers/media/i2c/Makefile
@@ -24,7 +24,6 @@ obj-$(CONFIG_VIDEO_BT819) += bt819.o
 obj-$(CONFIG_VIDEO_BT856) += bt856.o
 obj-$(CONFIG_VIDEO_BT866) += bt866.o
 obj-$(CONFIG_VIDEO_CCS) += ccs/
-obj-$(CONFIG_VIDEO_RK628) += rk628/
 obj-$(CONFIG_VIDEO_CCS_PLL) += ccs-pll.o
 obj-$(CONFIG_VIDEO_CS3308) += cs3308.o
 obj-$(CONFIG_VIDEO_CS5345) += cs5345.o

--- a/drivers/memory/eswin/Makefile
+++ b/drivers/memory/eswin/Makefile
@@ -11,6 +11,6 @@ obj-$(CONFIG_ESWIN_IOMMU_RSV)			+= es_iommu_rsv/
 obj-$(CONFIG_ESWIN_DMA_MEMCP)           += es_dma_memcp/
 obj-$(CONFIG_ESWIN_MALLOC_DMABUF)       += es_malloc_dmabuf/
 
-ES_MEM_HEADER := drivers/memory/eswin/
+ES_MEM_HEADER := $(srctree)/drivers/memory/eswin
 
-COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h include/linux)
+COPY_HEADERS := $(shell cp $(ES_MEM_HEADER)/*.h $(srctree)/include/linux)

--- a/drivers/memory/eswin/es_dev_buf/Makefile
+++ b/drivers/memory/eswin/es_dev_buf/Makefile
@@ -1,5 +1,5 @@
 obj-$(CONFIG_ESWIN_DEV_DMA_BUF) += es_dev_buf.o
 
-ES_DEV_DMA_BUF_HEADER := drivers/memory/eswin/es_dev_buf/include/linux
-COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h include/linux)
+ES_DEV_DMA_BUF_HEADER := $(srctree)/drivers/memory/eswin/es_dev_buf/include/linux
+COPY_HEADERS:=$(shell cp $(ES_DEV_DMA_BUF_HEADER)/*.h $(srctree)/include/linux)
 

--- a/drivers/net/wireless/ap12275/Makefile
+++ b/drivers/net/wireless/ap12275/Makefile
@@ -460,7 +460,7 @@ endif
 endif
 
 ARCH ?= riscv
-BCMDHD_ROOT = $(src)
+BCMDHD_ROOT = $(srctree)/$(src)
 #$(warning "BCMDHD_ROOT=$(BCMDHD_ROOT)")
 EXTRA_CFLAGS = $(DHDCFLAGS)
 EXTRA_CFLAGS += -DDHD_COMPILED=\"$(BCMDHD_ROOT)\"

--- a/drivers/soc/eswin/ai_driver/dsp/mloader/xt_mld_relocate.c
+++ b/drivers/soc/eswin/ai_driver/dsp/mloader/xt_mld_relocate.c
@@ -345,7 +345,7 @@ static xtmld_result_code_t relocate_relative(xtmld_state_t *lib_info,
 	if (a_ofs == 0) {
 		xtmld_ptr raddr;
 		status = reloc_addr_value(lib_info, load_32(addr) + rela->r_addend,
-				    &raddr);
+				    (unsigned int *)&raddr);
 		if (status != xtmld_success)
 			return status;
 		store_32(addr, (uint32_t)raddr);
@@ -356,7 +356,7 @@ static xtmld_result_code_t relocate_relative(xtmld_state_t *lib_info,
 		hi = load_32((uint32_t *)a_ptr + 1);
 		val = extract(lo, hi, a_ofs);
 		status = reloc_addr_value(lib_info, val + rela->r_addend,
-				    ((xtmld_ptr *)&val));
+				    (unsigned int *)&val);
 		if (status != xtmld_success)
 			return status;
 		combine(&lo, &hi, val, a_ofs);
@@ -380,7 +380,7 @@ static xtmld_result_code_t relocate_32_pcrel(xtmld_state_t *lib_info,
 	Elf32_Word a_ofs = (Elf32_Word)addr % 4;
 	// r_addend is the location of target in PIL
 	// get loaded address of target
-	status = reloc_addr_value(lib_info, rela->r_addend, &raddr);
+	status = reloc_addr_value(lib_info, rela->r_addend, (unsigned int *)&raddr);
 	if (status != xtmld_success)
 		return status;
 	// check if it's 4 byte aligned, C++ exception tables may have

--- a/drivers/staging/media/eswin/es-media-ext/Makefile
+++ b/drivers/staging/media/eswin/es-media-ext/Makefile
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-only
-ccflags-y := -I$(src)
-ccflags-y += -I$(src)/common/
-ccflags-y += -I$(src)/module/
-ccflags-y += -I$(src)/chn/
-ccflags-y += -I$(src)/proc/
-ccflags-y += -I$(src)/include/
+ccflags-y := -I$(srctree)/$(src)
+ccflags-y += -I$(srctree)/$(src)/common/
+ccflags-y += -I$(srctree)/$(src)/module/
+ccflags-y += -I$(srctree)/$(src)/chn/
+ccflags-y += -I$(srctree)/$(src)/proc/
+ccflags-y += -I$(srctree)/$(src)/include/
 
 es_media_ext_drv-objs := es_media_ext_drv_main.o \
 						./chn/dev_channel.o	\


### PR DESCRIPTION
Some fixes for out-of-tree building et. al. I came up with when working on Yocto Project integration (also see https://github.com/ziswiler/meta-riscv/tree/add-eswin-ebc77-support) for my upcoming FOSDEM'26 talk (also see https://fosdem.org/2026/schedule/event/LX3NNU-upstream-embedded-linux-on-risc-v-sbcs).

Thanks!